### PR TITLE
FEATURE(rdir): Add a conscience slots managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ An Ansible role for OpenIO rdir. Specifically, the responsibilities of this role
 | `openio_rdir_namespace` | `"OPENIO"` | Namespace |
 | `openio_rdir_provision_only` | `false` | Provision only without restarting services |
 | `openio_rdir_serviceid` | `"0"` | ID in gridinit |
+| `openio_rdir_slots` | `[rdir]` | The service's slot in conscience |
 | `openio_rdir_threads` | `1` | Number of threads |
 | `openio_rdir_volume` | `"/var/lib/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}"` | Path to store data |
 | `openio_rdir_worker` | `1` | Number of workers |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,4 +17,9 @@ openio_rdir_location: "{{ ansible_hostname }}.{{ openio_rdir_serviceid }}"
 
 openio_rdir_worker: 1
 openio_rdir_threads: 1
+
+openio_rdir_slots:
+  "{{ [ openio_rdir_type, openio_rdir_type ~ '-' ~ openio_rdir_location.split('.')[:-2] | join('-') ] \
+  if openio_rdir_location.split('.') | length > 2 \
+  else [ openio_rdir_type ] }}"
 ...

--- a/templates/watch-rdir.yml.j2
+++ b/templates/watch-rdir.yml.j2
@@ -1,4 +1,5 @@
 # {{ ansible_managed }}
+---
 host: {{ openio_rdir_bind_address }}
 port: {{ openio_rdir_bind_port }}
 type: rdir
@@ -13,3 +14,6 @@ stats:
   - {type: volume, path: {{ openio_rdir_volume }}}
   - {type: http, path: /status, parser: json}
   - {type: system}
+slots:
+  {{ openio_rdir_slots | to_nice_yaml | indent(2) }}
+...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 openio_rdir_sysconfig_dir: "/etc/oio/sds/{{ openio_rdir_namespace }}"
 openio_rdir_servicename: "rdir-{{ openio_rdir_serviceid }}"
+openio_rdir_type: rdir
 
 openio_rdir_definition_file: >
   "{{ openio_rdir_sysconfig_dir }}/


### PR DESCRIPTION
 ##### ISSUE TYPE
- Feature

 ##### SUMMARY
Add slots for multisite deployments

 ##### SCOPE (skeleton only)
- rdir

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Currently slots are unmanaged.
This commit add a default slot (servicetype's name).
For location superior to 2, a slot is added based on the first two locations

examples:
location:
  - host.id            slots => [rdir]
  - site.host.id       slots => [rdir, rdir-site]
  - region.site.host.id  slots => [rdir, rdir-region-site]