### PR TITLE
CHANGE(rdir): Ensure service is started or restarted at the end of role

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -4,18 +4,17 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repository
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
-    - role: namespace
-      openio_namespace_name: "{{ NS }}"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true
+    - role: namespace
+      openio_namespace_name: "{{ NS }}"
     - role: role_under_test
       openio_rdir_namespace: "{{ NS }}"
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,12 +49,37 @@
       dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ openio_rdir_servicename }}.yml"
   register: _rdir_conf
 
-- name: restart rdir
+- name: "restart rdir to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+  register: _restart_rdir
   when:
-    - _rdir_conf.changed
+    - _rdir_conf is changed
     - not openio_rdir_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure rdir is started"
+      command: gridinit_cmd start {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+      register: _start_rdir
+      changed_when: '"Success" in _start_rdir.stdout'
+      when:
+        - not openio_rdir_provision_only
+        - _restart_rdir is skipped
+      tags: configure
+
+    - name: check rdir
+      uri:
+        url: "http://{{ openio_rdir_bind_address }}:{{ openio_rdir_bind_port }}/status"
+        return_content: true
+        status_code: 200
+      register: _rdir_check
+      retries: 3
+      delay: 5
+      until: _rdir_check is success
+      changed_when: false
+      when:
+        - not openio_rdir_provision_only
+  when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION