### PR TITLE
CHANGE(rdir): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An Ansible role for OpenIO rdir. Specifically, the responsibilities of this role
 | `openio_rdir_threads` | `1` | Number of threads |
 | `openio_rdir_volume` | `"/var/lib/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}"` | Path to store data |
 | `openio_rdir_worker` | `1` | Number of workers |
+| `openio_rdir_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ openio_rdir_bind_port: 6300
 
 openio_rdir_volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}"
 openio_rdir_provision_only: false
+openio_rdir_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 openio_rdir_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
   {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_rdir_serviceid }}"
 openio_rdir_worker: 1

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_rdir_package_upgrade else 'present' }}"
   with_items: "{{ rdir_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_rdir_package_upgrade else 'present' }}"
   with_items: "{{ rdir_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION