### PR TITLE
BUGFIX/MEDIUM(rdir): Fix optimized check interval

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,8 +78,8 @@
         return_content: true
         status_code: 200
       register: _rdir_check
-      retries: 30
-      delay: 0.5
+      retries: 15
+      delay: 1
       until: _rdir_check is success
       changed_when: false
       tags: configure


### PR DESCRIPTION
 ##### SUMMARY

When the strategy `mitogen_free` is used, the ssh connection is persitant.
The usage of delay below 1 seconde is an issue.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION