### PR TITLE
FEATURE(rdir): Add `openio_rdir_instances` for multi install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,12 @@ script:
   - yamllint .
 
   # Create container and apply test playbook
-  - ./docker-tests/docker-tests.sh
+  - ./docker-tests/docker-tests.sh test_mono
+  - ./docker-tests/docker-tests.sh test_instances
 
   # Run functional tests on the container
-  #- SUT_ID=$(docker ps -qa) ./docker-tests/functional-tests.sh
-  - SUT_IP=172.17.0.2 ./docker-tests/functional-tests.sh
+  # instances
+  - SUT_IP=172.17.0.3 SUT_ID=$(docker ps -aq |sed '1q;d') ./docker-tests/functional-tests.sh
+  # mono
+  - SUT_IP=172.17.0.2 SUT_ID=$(docker ps -aq |sed '2q;d') ./docker-tests/functional-tests.sh
 ...

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ An Ansible role for OpenIO rdir. Specifically, the responsibilities of this role
 | `openio_rdir_provision_only` | `false` | Provision only without restarting services |
 | `openio_rdir_serviceid` | `"0"` | ID in gridinit |
 | `openio_rdir_slots` | `[rdir]` | The service's slot in conscience |
+| `openio_rdir_state` | `present` | If `absent` the configuration will be removed and service will be stopped. If `offline` the configure part is skipped.|
 | `openio_rdir_threads` | `1` | Number of threads |
 | `openio_rdir_volume` | `"/var/lib/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}"` | Path to store data |
 | `openio_rdir_worker` | `1` | Number of workers |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,4 +24,12 @@ openio_rdir_slots:
   "{{ [ openio_rdir_type, openio_rdir_type ~ '-' ~ openio_rdir_location.split('.')[:-2] | join('-') ] \
   if openio_rdir_location.split('.') | length > 2 \
   else [ openio_rdir_type ] }}"
+
+openio_rdir_state: present
+
+openio_rdir_instances:
+  - id: "{{ openio_rdir_serviceid }}"
+    port: "{{ openio_rdir_bind_port }}"
+    volume: "{{ openio_rdir_volume }}"
+    state: "{{ openio_rdir_state }}"
 ...

--- a/docker-tests/checks.bats
+++ b/docker-tests/checks.bats
@@ -6,7 +6,7 @@
 # Tests
 
 @test 'Status' {
-  run bash -c "curl http://${SUT_IP}:6300/status"
+  run bash -c "curl http://${SUT_IP}:6301/status"
   echo "output: "$output
   echo "status: "$status
   [[ "${status}" -eq "0" ]]
@@ -14,7 +14,7 @@
 }
 
 @test 'Config' {
-  run bash -c "curl http://${SUT_IP}:6300/config"
+  run bash -c "curl http://${SUT_IP}:6301/config"
   echo "output: "$output
   echo "status: "$status
   [[ "${status}" -eq "0" ]]

--- a/docker-tests/test_instances.yml
+++ b/docker-tests/test_instances.yml
@@ -17,4 +17,17 @@
       openio_namespace_name: "{{ NS }}"
     - role: role_under_test
       openio_rdir_namespace: "{{ NS }}"
+      openio_rdir_instances:
+        - id: "5"
+          port: 6301
+          state: "present"
+          volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/am"
+        - id: "2"
+          port: 6302
+          state: "absent"
+          volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/stram"
+        - id: "3"
+          port: 6303
+          state: "offline"
+          volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/gram"
 ...

--- a/docker-tests/test_mono.yml
+++ b/docker-tests/test_mono.yml
@@ -1,0 +1,36 @@
+# Test playbook
+---
+- hosts: all
+  become: true
+  vars:
+    NS: TRAVIS
+    openio_bootstrap: true
+  roles:
+    - role: users
+    - role: repository
+      openio_repository_no_log: false
+      openio_repository_mirror_host: mirror2.openio.io
+    - role: gridinit
+      openio_gridinit_namespace: "{{ NS }}"
+      openio_gridinit_per_ns: true
+    - role: namespace
+      openio_namespace_name: "{{ NS }}"
+    - role: role_under_test
+      openio_rdir_namespace: "{{ NS }}"
+      openio_rdir_serviceid: "5"
+      openio_rdir_bind_port: 6301
+      openio_rdir_volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/am"
+      openio_rdir_state: "present"
+    - role: role_under_test
+      openio_rdir_namespace: "{{ NS }}"
+      openio_rdir_serviceid: "2"
+      openio_rdir_bind_port: 6302
+      openio_rdir_volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/stram"
+      openio_rdir_state: "absent"
+    - role: role_under_test
+      openio_rdir_namespace: "{{ NS }}"
+      openio_rdir_serviceid: "3"
+      openio_rdir_bind_port: 6303
+      openio_rdir_volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/gram"
+      openio_rdir_state: "offline"
+...

--- a/tasks/absent.yml
+++ b/tasks/absent.yml
@@ -1,0 +1,34 @@
+# roles/rdir/tasks/absent.yml
+---
+- name: absent - Reset defaults
+  set_fact:
+    openio_rdir_servicename: "{{ rd.ansible_facts._rdir.name }}"
+    openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
+    openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
+    openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
+
+
+- name: absent - Remove configuration files
+  file:
+    dest: "{{ item.dest }}"
+    state: absent
+  with_items:
+    - dest: "{{ openio_rdir_sysconfig_dir }}/\
+        {{ openio_rdir_servicename }}/{{ openio_rdir_servicename }}-httpd.conf"
+    - dest: "{{ openio_rdir_gridinit_dir }}/{{ openio_rdir_gridinit_file_prefix }}\
+        {{ openio_rdir_servicename }}.conf"
+    - dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ openio_rdir_servicename }}.yml"
+  register: _rdir_conf
+
+- block:
+    - name: absent - stop rdir to apply the new configuration
+      shell: gridinit_cmd stop  {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+
+    - name: absent - Set properties
+      set_fact:
+        need_reload: true
+  when:
+    - _rdir_conf is changed
+    - not openio_rdir_provision_only
+
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,65 +16,61 @@
     - "{{ ansible_os_family }}.yml"
   tags: install
 
-- name: Ensure directories exists
-  file:
-    path: "{{ item.path }}"
-    state: directory
-    owner: "{{ item.owner | default('openio') }}"
-    group: "{{ item.group | default('openio') }}"
-    mode: "{{ item.mode | default(0755) }}"
-  with_items:
-    - path: "/etc/gridinit.d/{{ openio_rdir_namespace }}"
-    - path: "{{ openio_rdir_sysconfig_dir }}/{{ openio_rdir_servicename }}"
-    - path: "{{ openio_rdir_volume }}"
-    - path: "/etc/oio/sds/{{ openio_rdir_namespace }}/watch"
-    - path: "/var/log/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}"
-      owner: "{{ syslog_user }}"
-      mode: "0750"
-  tags: configure
+- name: Set properties
+  set_fact:
+    _rdir:
+      volume: "{{ item.1.volume }}"  # mandatory
+      name: "{{ openio_rdir_type }}-{{ item.1.id | default(item.0) }}"  # calculated
+      id: "{{ item.1.id | default(item.0) }}"  # mandatory
+      port: "{{ item.1.port }}"  # mandatory
+      state: "{{ item.1.state | d('present') }}"
+  with_indexed_items: "{{ openio_rdir_instances }}"
+  register: _rdir_properties
 
-- name: Generate configuration files
-  template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
+- name: Ensure namespace directories exist
+  file:
+    path: "{{ item }}"
+    state: directory
     owner: openio
     group: openio
-    mode: 0640
+    mode: "0755"
   with_items:
-    - src: "rdir.conf.j2"
-      dest: "{{ openio_rdir_sysconfig_dir }}/\
-        {{ openio_rdir_servicename }}/{{ openio_rdir_servicename }}.conf"
-    - src: "gridinit_rdir.conf.j2"
-      dest: "{{ openio_rdir_gridinit_dir }}/{{ openio_rdir_gridinit_file_prefix }}\
-        {{ openio_rdir_servicename }}.conf"
-    - src: "watch-rdir.yml.j2"
-      dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ openio_rdir_servicename }}.yml"
-  register: _rdir_conf
+    - "/etc/gridinit.d/{{ openio_rdir_namespace }}"
+    - "/etc/oio/sds/{{ openio_rdir_namespace }}/watch"
   tags: configure
 
-- name: "restart rdir to apply the new configuration"
-  shell: |
-    gridinit_cmd reload
-    gridinit_cmd restart  {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
-  register: _restart_rdir
+- name: "Include tasks for rdir state"
+  include_tasks: "{{ rd.ansible_facts._rdir.state }}.yml"
+  tags: configure
+  with_items: "{{ _rdir_properties.results }}"
+  loop_control:
+    loop_var: rd
+
+- name: "Reload gridinit to apply the new configuration"
+  shell: gridinit_cmd reload
   when:
+    - not openio_rdir_provision_only
+    - need_reload | default(false)
+
+- name: "restart rdir to apply the new configuration"
+  shell: gridinit_cmd restart  {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+  with_items: "{{ _rdir_properties.results }}"
+  when:
+    - item.ansible_facts._rdir.state == "present"
     - _rdir_conf is changed
     - not openio_rdir_provision_only
-  tags: configure
 
 - block:
     - name: "Ensure rdir is started"
-      command: gridinit_cmd start {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+      command: gridinit_cmd start {{ openio_rdir_namespace }}-{{ item.ansible_facts._rdir.name }}
       register: _start_rdir
       changed_when: '"Success" in _start_rdir.stdout'
-      when:
-        - not openio_rdir_provision_only
-        - _restart_rdir is skipped
-      tags: configure
+      when: item.ansible_facts._rdir.state == "present"
+      with_items: "{{ _rdir_properties.results }}"
 
     - name: check rdir
       uri:
-        url: "http://{{ openio_rdir_bind_address }}:{{ openio_rdir_bind_port }}/status"
+        url: "http://{{ openio_rdir_bind_address }}:{{ item.ansible_facts._rdir.port }}/status"
         return_content: true
         status_code: 200
       register: _rdir_check
@@ -82,8 +78,10 @@
       delay: 1
       until: _rdir_check is success
       changed_when: false
-      tags: configure
-      when:
-        - not openio_rdir_provision_only
-  when: openio_bootstrap | d(false)
+      with_items: "{{ _rdir_properties.results }}"
+      when: item.ansible_facts._rdir.state == "present"
+  tags: configure
+  when:
+    - not openio_rdir_provision_only
+    - openio_bootstrap | d(false)
 ...

--- a/tasks/offline.yml
+++ b/tasks/offline.yml
@@ -1,0 +1,34 @@
+# roles/rdir/tasks/offline.yml
+---
+- name: offline - Reset defaults
+  set_fact:
+    openio_rdir_servicename: "{{ rd.ansible_facts._rdir.name }}"
+    openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
+    openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
+    openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
+    openio_rdir_state: "{{ rd.ansible_facts._rdir.state }}"
+
+- name: offline -Generate configuration files
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: openio
+    group: openio
+    mode: 0640
+  with_items:
+    - src: "gridinit_rdir.conf.j2"
+      dest: "{{ openio_rdir_gridinit_dir }}/{{ openio_rdir_gridinit_file_prefix }}\
+        {{ openio_rdir_servicename }}.conf"
+  register: _rdir_conf
+
+- block:
+    - name: offline - stop rdir to apply the new configuration
+      shell: gridinit_cmd stop  {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+
+    - name: offline - Set properties
+      set_fact:
+        need_reload: true
+  when:
+    - _rdir_conf is changed
+    - not openio_rdir_provision_only
+...

--- a/tasks/present.yml
+++ b/tasks/present.yml
@@ -1,0 +1,51 @@
+# roles/rdir/tasks/present.yml
+---
+
+- name: present - Reset defaults
+  set_fact:
+    openio_rdir_servicename: "{{ rd.ansible_facts._rdir.name }}"
+    openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
+    openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
+    openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
+    openio_rdir_state: "{{ rd.ansible_facts._rdir.state }}"
+
+- name: present - Ensure directories exists
+  file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner | default('openio') }}"
+    group: "{{ item.group | default('openio') }}"
+    mode: "{{ item.mode | default(0755) }}"
+  with_items:
+    - path: "{{ openio_rdir_volume }}"
+    - path: "{{ openio_rdir_sysconfig_dir }}/{{ openio_rdir_servicename }}"
+    - path: "/var/log/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}"
+      owner: "{{ syslog_user }}"
+      mode: "0750"
+
+- name: present - Generate configuration files
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: openio
+    group: openio
+    mode: 0640
+  with_items:
+    - src: "rdir.conf.j2"
+      dest: "{{ openio_rdir_sysconfig_dir }}/\
+        {{ openio_rdir_servicename }}/{{ openio_rdir_servicename }}.conf"
+    - src: "gridinit_rdir.conf.j2"
+      dest: "{{ openio_rdir_gridinit_dir }}/{{ openio_rdir_gridinit_file_prefix }}\
+        {{ openio_rdir_servicename }}.conf"
+    - src: "watch-rdir.yml.j2"
+      dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ openio_rdir_servicename }}.yml"
+  register: _rdir_conf
+
+- block:
+    - name: present - Set properties
+      set_fact:
+        need_reload: true
+  when:
+    - _rdir_conf is changed
+    - not openio_rdir_provision_only
+...

--- a/templates/gridinit_rdir.conf.j2
+++ b/templates/gridinit_rdir.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 [Service.{{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}]
 command=/usr/bin/oio-rdir-server /etc/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}/{{ openio_rdir_servicename }}.conf
-enabled=true
+enabled={{ 'false' if openio_rdir_state == 'offline' else 'true' }}
 start_at_boot=true
 on_die=respawn
 group={{ openio_rdir_namespace }},rdir,{{ openio_rdir_serviceid }}


### PR DESCRIPTION
 ##### SUMMARY

Introduce `openio_rdir_instances`.
This `list` of instances allows to install many instances of rdir in a single role's iteration.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
    - role: rdir
      openio_rdir_namespace: "{{ NS }}"
      openio_rdir_instances:
        - id: "5"
          port: 6301
          state: "present"
          volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/am"
        - id: "2"
          port: 6302
          state: "absent"
          volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/stram"
        - id: "3"
          port: 6303
          state: "offline"
          volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/gram"
```