### PR TITLE
BUGFIX/MINOR(rdir): Add missing tags install/configure

### DIFF
--- a/tasks/absent.yml
+++ b/tasks/absent.yml
@@ -6,7 +6,9 @@
     openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
     openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
     openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
-
+  tags:
+    - install
+    - configure
 
 - name: absent - Remove configuration files
   file:
@@ -19,6 +21,7 @@
         {{ openio_rdir_servicename }}.conf"
     - dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ openio_rdir_servicename }}.yml"
   register: _rdir_conf
+  tags: configure
 
 - block:
     - name: absent - stop rdir to apply the new configuration
@@ -30,5 +33,5 @@
   when:
     - _rdir_conf is changed
     - not openio_rdir_provision_only
-
+  tags: configure
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,9 @@
       state: "{{ item.1.state | d('present') }}"
   with_indexed_items: "{{ openio_rdir_instances }}"
   register: _rdir_properties
+  tags:
+    - install
+    - configure
 
 - name: Ensure namespace directories exist
   file:
@@ -41,19 +44,23 @@
 
 - name: "Include tasks for rdir state"
   include_tasks: "{{ rd.ansible_facts._rdir.state }}.yml"
-  tags: configure
+  tags:
+    - install
+    - configure
   with_items: "{{ _rdir_properties.results }}"
   loop_control:
     loop_var: rd
 
 - name: "Reload gridinit to apply the new configuration"
   shell: gridinit_cmd reload
+  tags: configure
   when:
     - not openio_rdir_provision_only
     - need_reload | default(false)
 
 - name: "restart rdir to apply the new configuration"
   shell: gridinit_cmd restart  {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+  tags: configure
   with_items: "{{ _rdir_properties.results }}"
   when:
     - item.ansible_facts._rdir.state == "present"

--- a/tasks/offline.yml
+++ b/tasks/offline.yml
@@ -7,8 +7,11 @@
     openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
     openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
     openio_rdir_state: "{{ rd.ansible_facts._rdir.state }}"
+  tags:
+    - install
+    - configure
 
-- name: offline -Generate configuration files
+- name: offline - Generate configuration files
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -20,6 +23,7 @@
       dest: "{{ openio_rdir_gridinit_dir }}/{{ openio_rdir_gridinit_file_prefix }}\
         {{ openio_rdir_servicename }}.conf"
   register: _rdir_conf
+  tags: configure
 
 - block:
     - name: offline - stop rdir to apply the new configuration
@@ -31,4 +35,5 @@
   when:
     - _rdir_conf is changed
     - not openio_rdir_provision_only
+  tags: configure
 ...

--- a/tasks/present.yml
+++ b/tasks/present.yml
@@ -8,6 +8,9 @@
     openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
     openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
     openio_rdir_state: "{{ rd.ansible_facts._rdir.state }}"
+  tags:
+    - install
+    - configure
 
 - name: present - Ensure directories exists
   file:
@@ -22,6 +25,7 @@
     - path: "/var/log/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0750"
+  tags: install
 
 - name: present - Generate configuration files
   template:
@@ -40,6 +44,7 @@
     - src: "watch-rdir.yml.j2"
       dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ openio_rdir_servicename }}.yml"
   register: _rdir_conf
+  tags: configure
 
 - block:
     - name: present - Set properties
@@ -48,4 +53,5 @@
   when:
     - _rdir_conf is changed
     - not openio_rdir_provision_only
+  tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

The tags `install` and `configure` are broken since the commit d5cb654

 ##### IMPACT
 N/A

 ##### ADDITIONAL INFORMATION