### PR TITLE
BUGFIX/MEDIUM(rdir): Define internal variables for loop interation in…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 # .travis.yml Execution script for role tests on Travis-CI
 ---
-dist: xenial
+dist: bionic
 sudo: required
 
 env:
   global:
-    - ANSIBLE_VERSION=2.5
+    - ANSIBLE_VERSION=2.9
   matrix:
     - DISTRIBUTION: centos
       VERSION: 7
 #    - DISTRIBUTION: centos
 #      VERSION: 8
-    - DISTRIBUTION: ubuntu
-      VERSION: 16.04
+#    - DISTRIBUTION: ubuntu
+#      VERSION: 16.04
     - DISTRIBUTION: ubuntu
       VERSION: 18.04
 #    - DISTRIBUTION: debian
@@ -20,6 +20,10 @@ env:
 
 services:
   - docker
+
+language: python
+python:
+  - "3.6"
 
 before_install:
   # Install latest Git

--- a/docker-tests/README.md
+++ b/docker-tests/README.md
@@ -1,20 +1,10 @@
 # Docker test environment
 
-1. Fetch the test branch: `git fetch origin docker-tests`
-2. Create a Git worktree for the test code: `git worktree add docker-tests docker-tests`. This will create a directory `docker-tests/`
-3. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/cdelgehier/docker_images_ansible/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
+1. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/bertvv/ansible-testing/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
 
     ```
-    DISTRIBUTION=centos VERSION=7 ANSIBLE_VERSION=2.5 ./docker-tests/docker-tests.sh
-    DISTRIBUTION=ubuntu VERSION=16.04 ANSIBLE_VERSION=2.5 ./docker-tests/docker-tests.sh
+    DISTRIBUTION=centos VERSION=7 ANSIBLE_VERSION=2.9 ./docker-tests/docker-tests.sh
+    DISTRIBUTION=ubuntu VERSION=18.04 ANSIBLE_VERSION=2.9 ./docker-tests/docker-tests.sh
     ```
-4. You can test another use case by adding an argument to the script. An argument `<another>` will apply a playbook `<another.yml>`
 
-5. You can run functionnal tests locally like that:
-
-    ```
-    SUT_ID=9acda29c356b ./docker-tests/functional-tests.sh
-    SUT_IP=172.17.0.2   ./docker-tests/functional-tests.sh
-    ```
-   
 The specific combinations of distributions and versions that are supported by this role are specified in `.travis.yml`.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,14 +3,14 @@ galaxy_info:
   author: Cedric DELGEHIER <cedric@openio.io>
   description: Install and configure rdir OpenIO
   company: OpenIO
-  license: Apache
+  license: AGPLv3
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.9
 
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
+        - bionic
     - name: EL
       versions:
         - 7

--- a/tasks/absent.yml
+++ b/tasks/absent.yml
@@ -2,10 +2,10 @@
 ---
 - name: absent - Reset defaults
   set_fact:
-    openio_rdir_servicename: "{{ rd.ansible_facts._rdir.name }}"
-    openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
-    openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
-    openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
+    _openio_rdir_servicename: "{{ rd.ansible_facts._rdir.name }}"
+    _openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
+    _openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
+    _openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
   tags:
     - install
     - configure
@@ -16,16 +16,16 @@
     state: absent
   with_items:
     - dest: "{{ openio_rdir_sysconfig_dir }}/\
-        {{ openio_rdir_servicename }}/{{ openio_rdir_servicename }}-httpd.conf"
+        {{ _openio_rdir_servicename }}/{{ _openio_rdir_servicename }}-httpd.conf"
     - dest: "{{ openio_rdir_gridinit_dir }}/{{ openio_rdir_gridinit_file_prefix }}\
-        {{ openio_rdir_servicename }}.conf"
-    - dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ openio_rdir_servicename }}.yml"
+        {{ _openio_rdir_servicename }}.conf"
+    - dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ _openio_rdir_servicename }}.yml"
   register: _rdir_conf
   tags: configure
 
 - block:
     - name: absent - stop rdir to apply the new configuration
-      shell: gridinit_cmd stop  {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+      shell: gridinit_cmd stop  {{ openio_rdir_namespace }}-{{ _openio_rdir_servicename }}
 
     - name: absent - Set properties
       set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
     - need_reload | default(false)
 
 - name: "restart rdir to apply the new configuration"
-  shell: gridinit_cmd restart  {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+  command: "gridinit_cmd restart  {{ openio_rdir_namespace }}-{{ item.ansible_facts._rdir.name }}"
   tags: configure
   with_items: "{{ _rdir_properties.results }}"
   when:
@@ -69,7 +69,7 @@
 
 - block:
     - name: "Ensure rdir is started"
-      command: gridinit_cmd start {{ openio_rdir_namespace }}-{{ item.ansible_facts._rdir.name }}
+      command: "gridinit_cmd start {{ openio_rdir_namespace }}-{{ item.ansible_facts._rdir.name }}"
       register: _start_rdir
       changed_when: '"Success" in _start_rdir.stdout'
       when: item.ansible_facts._rdir.state == "present"

--- a/tasks/offline.yml
+++ b/tasks/offline.yml
@@ -2,11 +2,11 @@
 ---
 - name: offline - Reset defaults
   set_fact:
-    openio_rdir_servicename: "{{ rd.ansible_facts._rdir.name }}"
-    openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
-    openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
-    openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
-    openio_rdir_state: "{{ rd.ansible_facts._rdir.state }}"
+    _openio_rdir_servicename: "{{ rd.ansible_facts._rdir.name }}"
+    _openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
+    _openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
+    _openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
+    _openio_rdir_state: "{{ rd.ansible_facts._rdir.state }}"
   tags:
     - install
     - configure
@@ -21,13 +21,13 @@
   with_items:
     - src: "gridinit_rdir.conf.j2"
       dest: "{{ openio_rdir_gridinit_dir }}/{{ openio_rdir_gridinit_file_prefix }}\
-        {{ openio_rdir_servicename }}.conf"
+        {{ _openio_rdir_servicename }}.conf"
   register: _rdir_conf
   tags: configure
 
 - block:
     - name: offline - stop rdir to apply the new configuration
-      shell: gridinit_cmd stop  {{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}
+      shell: gridinit_cmd stop  {{ openio_rdir_namespace }}-{{ _openio_rdir_servicename }}
 
     - name: offline - Set properties
       set_fact:

--- a/tasks/present.yml
+++ b/tasks/present.yml
@@ -3,11 +3,13 @@
 
 - name: present - Reset defaults
   set_fact:
-    openio_rdir_servicename: "{{ rd.ansible_facts._rdir.name }}"
-    openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
-    openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
-    openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
-    openio_rdir_state: "{{ rd.ansible_facts._rdir.state }}"
+    _openio_rdir_servicename: "{{ rd.ansible_facts._rdir.name }}"
+    _openio_rdir_bind_port: "{{ rd.ansible_facts._rdir.port }}"
+    _openio_rdir_serviceid: "{{ rd.ansible_facts._rdir.id }}"
+    _openio_rdir_volume: "{{ rd.ansible_facts._rdir.volume }}"
+    _openio_rdir_state: "{{ rd.ansible_facts._rdir.state }}"
+    _openio_rdir_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
+  {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ rd.ansible_facts._rdir.id }}"
   tags:
     - install
     - configure
@@ -20,9 +22,9 @@
     group: "{{ item.group | default('openio') }}"
     mode: "{{ item.mode | default(0755) }}"
   with_items:
-    - path: "{{ openio_rdir_volume }}"
-    - path: "{{ openio_rdir_sysconfig_dir }}/{{ openio_rdir_servicename }}"
-    - path: "/var/log/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}"
+    - path: "{{ _openio_rdir_volume }}"
+    - path: "{{ openio_rdir_sysconfig_dir }}/{{ _openio_rdir_servicename }}"
+    - path: "/var/log/oio/sds/{{ openio_rdir_namespace }}/{{ _openio_rdir_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0750"
   tags: install
@@ -37,12 +39,12 @@
   with_items:
     - src: "rdir.conf.j2"
       dest: "{{ openio_rdir_sysconfig_dir }}/\
-        {{ openio_rdir_servicename }}/{{ openio_rdir_servicename }}.conf"
+        {{ _openio_rdir_servicename }}/{{ _openio_rdir_servicename }}.conf"
     - src: "gridinit_rdir.conf.j2"
       dest: "{{ openio_rdir_gridinit_dir }}/{{ openio_rdir_gridinit_file_prefix }}\
-        {{ openio_rdir_servicename }}.conf"
+        {{ _openio_rdir_servicename }}.conf"
     - src: "watch-rdir.yml.j2"
-      dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ openio_rdir_servicename }}.yml"
+      dest: "{{ openio_rdir_sysconfig_dir }}/watch/{{ _openio_rdir_servicename }}.yml"
   register: _rdir_conf
   tags: configure
 

--- a/templates/gridinit_rdir.conf.j2
+++ b/templates/gridinit_rdir.conf.j2
@@ -1,10 +1,10 @@
 # {{ ansible_managed }}
-[Service.{{ openio_rdir_namespace }}-{{ openio_rdir_servicename }}]
-command=/usr/bin/oio-rdir-server {{ openio_rdir_sysconfig_dir }}/{{ openio_rdir_servicename }}/{{ openio_rdir_servicename }}.conf
-enabled={{ 'false' if openio_rdir_state == 'offline' else 'true' }}
+[Service.{{ openio_rdir_namespace }}-{{ _openio_rdir_servicename }}]
+command=/usr/bin/oio-rdir-server {{ openio_rdir_sysconfig_dir }}/{{ _openio_rdir_servicename }}/{{ _openio_rdir_servicename }}.conf
+enabled={{ 'false' if _openio_rdir_state == 'offline' else 'true' }}
 start_at_boot=true
 on_die=respawn
-group={{ openio_rdir_namespace }},rdir,{{ openio_rdir_serviceid }}
+group={{ openio_rdir_namespace }},rdir,{{ _openio_rdir_serviceid }}
 uid=openio
 gid=openio
 env.PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin

--- a/templates/rdir.conf.j2
+++ b/templates/rdir.conf.j2
@@ -1,14 +1,14 @@
 # {{ ansible_managed }}
 [rdir-server]
 bind_addr = {{ openio_rdir_bind_address }}
-bind_port = {{ openio_rdir_bind_port }}
+bind_port = {{ _openio_rdir_bind_port }}
 namespace = {{ openio_rdir_namespace }}
 # Currently, only 1 worker is allowed to avoid concurrent access to leveldb database
 workers = {{ openio_rdir_worker }}
 worker_class = sync
 threads = {{ openio_rdir_threads }}
-db_path = {{ openio_rdir_volume }}
+db_path = {{ _openio_rdir_volume }}
 log_facility = LOG_LOCAL0
 log_level = info
 log_address = /dev/log
-syslog_prefix = OIO,{{ openio_rdir_namespace }},rdir,{{ openio_rdir_serviceid }}
+syslog_prefix = OIO,{{ openio_rdir_namespace }},rdir,{{ _openio_rdir_serviceid }}

--- a/templates/watch-rdir.yml.j2
+++ b/templates/watch-rdir.yml.j2
@@ -1,17 +1,17 @@
 # {{ ansible_managed }}
 ---
 host: {{ openio_rdir_bind_address }}
-port: {{ openio_rdir_bind_port }}
+port: {{ _openio_rdir_bind_port }}
 type: rdir
-{% if openio_rdir_location | ipaddr %}
-location: {{ openio_rdir_location | replace(".", "-") }}
+{% if _openio_rdir_location | ipaddr %}
+location: {{ _openio_rdir_location | replace(".", "-") }}
 {% else %}
-location: {{ openio_rdir_location }}
+location: {{ _openio_rdir_location }}
 {% endif %}
 checks:
   - {type: tcp}
 stats:
-  - {type: volume, path: {{ openio_rdir_volume }}}
+  - {type: volume, path: {{ _openio_rdir_volume }}}
   - {type: http, path: /status, parser: json}
   - {type: system}
 slots:


### PR DESCRIPTION
…stead of rewrite role's defaults

 ##### SUMMARY

Previously, the role rewrote these variables:

- openio_rdir_servicename
- openio_rdir_bind_port
- openio_rdir_serviceid
- openio_rdir_volume
- openio_rdir_state

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
The /etc/oio/sds/NS/inventory.yml was wrong, especially the port.