### PR TITLE
CHANGE(rdir): Change default of `gridinit_dir`, `gridinit_file_prefix…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@
 openio_rdir_namespace: "{{ namespace | default('OPENIO') }}"
 openio_rdir_serviceid: "0"
 
-openio_rdir_gridinit_dir: "/etc/gridinit.d/{{ openio_rdir_namespace }}"
-openio_rdir_gridinit_file_prefix: ""
+openio_rdir_gridinit_dir: "{{ openio_gridinit_d | d('/etc/gridinit.d/') }}"
+openio_rdir_gridinit_file_prefix: "{{ openio_rdir_namespace }}-"
 
 openio_rdir_bind_interface: "{{ ansible_default_ipv4.alias }}"
 openio_rdir_bind_address:
@@ -12,7 +12,7 @@ openio_rdir_bind_address:
 openio_rdir_bind_port: 6300
 
 openio_rdir_volume: "/var/lib/oio/sds/{{ openio_rdir_namespace }}/{{ openio_rdir_servicename }}"
-openio_rdir_provision_only: false
+openio_rdir_provision_only: "{{ openio_maintenance_mode | d(false) | bool }}"
 openio_rdir_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 openio_rdir_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
   {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_rdir_serviceid }}"

--- a/docker-tests/test_instances.yml
+++ b/docker-tests/test_instances.yml
@@ -12,7 +12,7 @@
       openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
-      openio_gridinit_per_ns: true
+      #openio_gridinit_per_ns: true
     - role: namespace
       openio_namespace_name: "{{ NS }}"
     - role: role_under_test

--- a/docker-tests/test_mono.yml
+++ b/docker-tests/test_mono.yml
@@ -12,7 +12,7 @@
       openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
-      openio_gridinit_per_ns: true
+      #openio_gridinit_per_ns: true
     - role: namespace
       openio_namespace_name: "{{ NS }}"
     - role: role_under_test

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,6 @@
     group: openio
     mode: "0755"
   with_items:
-    - "/etc/gridinit.d/{{ openio_rdir_namespace }}"
     - "/etc/oio/sds/{{ openio_rdir_namespace }}/watch"
   tags: configure
 


### PR DESCRIPTION
…` and `provision_only`

 ##### SUMMARY

The playbook hardcode these calls. Now the defaults are good and there is no more hardcode.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION