### PR TITLE
CHANGE(rdir): Set the bind_interface to openio_bind_interface by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ openio_rdir_serviceid: "0"
 openio_rdir_gridinit_dir: "{{ openio_gridinit_d | d('/etc/gridinit.d/') }}"
 openio_rdir_gridinit_file_prefix: "{{ openio_rdir_namespace }}-"
 
-openio_rdir_bind_interface: "{{ ansible_default_ipv4.alias }}"
+openio_rdir_bind_interface: "{{ openio_bind_interface | d(ansible_default_ipv4.alias) }}"
 openio_rdir_bind_address:
   "{{ openio_bind_address \
   | default(hostvars[inventory_hostname]['ansible_' + openio_rdir_bind_interface]['ipv4']['address']) }}"


### PR DESCRIPTION
 ##### SUMMARY

As bind_address, a good default is openio_bind_interface

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION